### PR TITLE
Still save environment textures when file extension is not specified.

### DIFF
--- a/src/MrSwizzleApplication.cpp
+++ b/src/MrSwizzleApplication.cpp
@@ -1538,8 +1538,7 @@ MrSwizzleApplication::saveImages(const std::string& filePathName, bool gameOnly)
         size_t extension = filePathName.rfind(".");
         if (extension == std::string::npos)
         {
-            LOG_CRITICAL("Failed to find file extension in " << filePathName);
-            return false;
+            extension = filePathName.size();
         }
 
         std::string pathName = filePathName.substr(0, pathEnd+1);


### PR DESCRIPTION
Thanks for the awesome & useful tool!

I noticed that when I pressed the `save environment` button, the MrSwizzle will export images only if a file extension is provided, like `foo.png`. If I type `foo`, it does nothing. But they all end up being saved as dds cubemaps, the file extension is not really used. I made a slight change to export textures whether a file extension is found or not.

